### PR TITLE
Data.Array.Base: remove useless SPECIALISE pragmas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc: ['9.10', '9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-22.04', 'windows-latest']
 
     name: Build on ${{ matrix.os }} with GHC ${{ matrix.ghc }}
 

--- a/Data/Array/Base.hs
+++ b/Data/Array/Base.hs
@@ -587,11 +587,6 @@ cmpIntUArray arr1@(UArray l1 u1 n1 _) arr2@(UArray l2 u2 n2 _) =
 -----------------------------------------------------------------------------
 -- Showing and Reading IArrays
 
-{-# SPECIALISE
-    showsIArray :: (IArray UArray e, Ix i, Show i, Show e) =>
-                   Int -> UArray i e -> ShowS
-  #-}
-
 showsIArray :: (IArray a e, Ix i, Show i, Show e) => Int -> a i e -> ShowS
 showsIArray p a =
     showParen (p > appPrec) $
@@ -599,11 +594,7 @@ showsIArray p a =
     shows (bounds a) .
     showChar ' ' .
     shows (assocs a)
-
-{-# SPECIALISE
-    readIArray :: (IArray UArray e, Ix i, Read i, Read e) =>
-                   ReadPrec (UArray i e)
-  #-}
+    
 
 readIArray :: (IArray a e, Ix i, Read i, Read e) => ReadPrec (a i e)
 readIArray = parens $ prec appPrec $


### PR DESCRIPTION
These SPECIALISE pragmas don't actually do anything, and starting with GHC 9.14 (with [GHC MR !12319](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/12319)) will cause a warning to be emitted. This commit simply removes them.