### PR TITLE
Use ubuntu-22.04 instead of the latest on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc: ['9.10', '9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-22.04', 'windows-latest']
 
     name: Build on ${{ matrix.os }} with GHC ${{ matrix.ghc }}
 


### PR DESCRIPTION
CI with older ghc on ubuntu-24.04 seems to not work, pin to 22.04.