### PR TITLE
Remove confusing comparison and unsubstantiated performance claims from the docs

### DIFF
--- a/Data/Array.hs
+++ b/Data/Array.hs
@@ -57,13 +57,6 @@ import Data.Ix
 import GHC.Arr  -- Most of the hard work is done here
 
 {- $intro
-Haskell provides indexable /arrays/, which may be thought of as functions
-whose domains are isomorphic to contiguous subsets of the integers.
-Functions restricted in this way can be implemented efficiently;
-in particular, a programmer may reasonably expect rapid access to
-the components.  To ensure the possibility of such an implementation,
-arrays are treated as data, not as general functions.
-
 Since most array functions involve the class 'Ix', this module is exported
 from "Data.Array" so that modules need not import both "Data.Array" and
 "Data.Ix".


### PR DESCRIPTION
@july541 I'd like to submit this PR that removes quite confusing documentation (comparison of arrays with functions which ends with the sentence "_arrays are treated as data, not as general functions_"), and vague claims about performance when there is no benchmark suite to substantiate them. :)